### PR TITLE
fix: Error with duplicate letters

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,27 +36,32 @@ const wordlePrompt = {
 async function check(guess) {
   // clear previous results
   console.clear();
-  let results = "";
   let puzzleNotMatchedLetters = puzzle;
-  // loop over each letter in the word
-  for (let i in guess) {
-    const letter = guess[i];
+  const colors = Array(guess.length).fill(chalk.white.bgGrey);
+  // loop through guess and mark green if fully correct
+  for (let i = 0; i < guess.length; i++) {
     // check if the letter at the specified index in the guess word exactly
     // matches the letter at the specified index in the puzzle
-    if (letter === puzzle[i]) {
-      puzzleNotMatchedLetters = puzzleNotMatchedLetters.replace(letter, "");
-      results += chalk.white.bgGreen.bold(` ${letter} `);
-      continue;
+    if (guess[i] === puzzleNotMatchedLetters[i]) {
+      colors[i] = chalk.white.bgGreen;
+      // remove letter from answer, so it's not scored again
+      puzzleNotMatchedLetters = puzzleNotMatchedLetters.replace(guess[i], " ");
     }
+  }
+  // loop through guess and mark yellow if partially correct
+  for (let i = 0; i < guess.length; i++) {
     // check if the letter at the specified index in the guess word is at least
     // contained in the puzzle at some other position
-    if (puzzleNotMatchedLetters.includes(letter)) {
-      puzzleNotMatchedLetters = puzzleNotMatchedLetters.replace(letter, "");
-      results += chalk.white.bgYellow.bold(` ${letter} `);
-      continue;
+    if (guess[i] !== puzzleNotMatchedLetters[i] && puzzleNotMatchedLetters.includes(guess[i])) {
+      colors[i] = chalk.white.bgYellow;
+      // remove letter from answer, so it's not scored again
+      puzzleNotMatchedLetters = puzzleNotMatchedLetters.replace(guess[i], " ");
     }
-    // otherwise the letter doesn't exist at all in the puzzle
-    results += chalk.white.bgGrey.bold(` ${letter} `);
+  }
+  let results = "";
+  // loop over each letter and use its color to add it to the output
+  for (let i = 0; i < guess.length; i++) {
+    results += colors[i].bold(` ${guess[i]} `);
   }
   globalResults += results.padEnd(results.length + TERMINAL_COLS - 15, " ");
   // 15 in above code is 5 letters and 2 spaces in start and end of characters, 3 char for a letter, total 3 *5 =15


### PR DESCRIPTION
Although it was attempted to be fixed by an earlier commit (#7), it is still incorrect

Previously, if the guess contains duplicate letters, letters in the wrong spot could appear yellow even if there is only 1 occurrence in the word.

### Example:

If the answer is `"THOSE"`, if a player were to guess the word `"GEESE"`, the algorithm above would produce the colors:

![image](https://user-images.githubusercontent.com/20955511/152869388-7d797f52-ba64-4c07-828c-9a197d5f1374.png)

This would imply that the correct answer has one E's in the wrong location and one E in the correct location (a total of two E's).

The result should, however, only show 1 E being in the word:

![image](https://user-images.githubusercontent.com/20955511/152869442-fcd84307-bb4c-498b-ab7d-e549ce919aa4.png)

### Another example:

If the answer is `"DREAD"`, and `"ADDED"` is guessed, the result produced would be:

!['YELLOW', 'YELLOW', 'YELLOW', 'YELLOW', 'GREEN'](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/b8qnb698dwvt8ys7tc83.png) 

This implies no letters are missing, but in fact, one of the D's is wrong and the R is missing. Only *one* of the wrongly placed D's should be marked Yellow.

!['YELLOW', 'YELLOW', 'GRAY', 'YELLOW', 'GREEN'](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/h7rwe7j9orb4u6azptpa.png) 

----

The change I've made to the code accounts for these duplicates and produces results similar to the original Wordle.